### PR TITLE
Fix OpenStreetMap tiles being blocked with a 403 notice

### DIFF
--- a/Mobile Front-end (MA)/Mobile-Front-MA/app/build.gradle
+++ b/Mobile Front-end (MA)/Mobile-Front-MA/app/build.gradle
@@ -9,7 +9,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.example.mobile_front_ma"
+        applicationId "rs.ac.uns.ftn.zgazenisendvic"
         minSdk 33
         targetSdk 36
         versionCode 1

--- a/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/MobileFrontApp.java
+++ b/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/MobileFrontApp.java
@@ -1,19 +1,35 @@
 package com.example.mobile_front_ma;
 
 import android.app.Application;
+import android.content.Context;
 
+import com.example.mobile_front_ma.data.network.GeoApiClient;
 import com.example.mobile_front_ma.data.realtime.PanicRealtimeManager;
 
+import org.osmdroid.config.Configuration;
+
 /**
- * Custom Application: initialises the app-scoped panic realtime manager (spec 2.6.3) so it is
- * available to the admin screens and to {@code PanicForegroundService}, which drives the panic
- * socket's connection lifetime.
+ * Custom Application: configures osmdroid once for every map screen, and initialises the
+ * app-scoped panic realtime manager (spec 2.6.3) so it is available to the admin screens and to
+ * {@code PanicForegroundService}, which drives the panic socket's connection lifetime.
  */
 public class MobileFrontApp extends Application {
 
     @Override
     public void onCreate() {
         super.onCreate();
+        initOsmdroid();
         PanicRealtimeManager.init(this);
+    }
+
+    /**
+     * osmdroid must know who we are before the first tile request. OpenStreetMap's tile servers
+     * answer the default {@code com.example.*} package name with HTTP 403, so we identify the app
+     * with the same agent the Nominatim and OSRM clients already send.
+     */
+    private void initOsmdroid() {
+        Configuration.getInstance().load(this,
+                getSharedPreferences("osmdroid", Context.MODE_PRIVATE));
+        Configuration.getInstance().setUserAgentValue(GeoApiClient.USER_AGENT);
     }
 }

--- a/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/activities/RideHistoryDetailActivity.java
+++ b/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/activities/RideHistoryDetailActivity.java
@@ -2,7 +2,6 @@ package com.example.mobile_front_ma.activities;
 
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
-import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -29,7 +28,6 @@ import com.example.mobile_front_ma.models.dto.RideRatingDto;
 import com.example.mobile_front_ma.util.Resource;
 import com.example.mobile_front_ma.viewmodels.RideDetailViewModel;
 
-import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
@@ -90,11 +88,6 @@ public class RideHistoryDetailActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        Context ctx = getApplicationContext();
-        Configuration.getInstance().load(ctx,
-                ctx.getSharedPreferences("osmdroid", Context.MODE_PRIVATE));
-        Configuration.getInstance().setUserAgentValue(ctx.getPackageName());
 
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_ride_history_detail);

--- a/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/data/network/GeoApiClient.java
+++ b/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/data/network/GeoApiClient.java
@@ -17,8 +17,9 @@ public final class GeoApiClient {
     private static final String NOMINATIM_BASE_URL = "https://nominatim.openstreetmap.org/";
     private static final String OSRM_BASE_URL = "https://router.project-osrm.org/";
 
-    // Nominatim's usage policy requires an identifying User-Agent on every request.
-    private static final String USER_AGENT = "ZgazeniSendvicMA/1.0 (SIIT student project)";
+    // OSM's services (Nominatim, OSRM and the tile servers) all require an identifying
+    // User-Agent. Shared with MobileFrontApp, which applies it to osmdroid's tile requests.
+    public static final String USER_AGENT = "ZgazeniSendvicMA/1.0 (SIIT student project)";
 
     private static OkHttpClient httpClient;
     private static NominatimApi nominatimApi;

--- a/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/ui/map/MapFragment.java
+++ b/Mobile Front-end (MA)/Mobile-Front-MA/app/src/main/java/com/example/mobile_front_ma/ui/map/MapFragment.java
@@ -1,6 +1,5 @@
 package com.example.mobile_front_ma.ui.map;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +19,6 @@ import com.example.mobile_front_ma.models.RouteEstimate;
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 
-import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
@@ -56,16 +54,6 @@ public class MapFragment extends Fragment
     private Polyline routeLine;
     private Marker startMarker;
     private Marker endMarker;
-
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        // osmdroid needs an identifying user agent set before any tile/map request.
-        Context ctx = requireContext().getApplicationContext();
-        Configuration.getInstance().load(ctx,
-                ctx.getSharedPreferences("osmdroid", Context.MODE_PRIVATE));
-        Configuration.getInstance().setUserAgentValue(ctx.getPackageName());
-    }
 
     @Nullable
     @Override


### PR DESCRIPTION
OSM served a "403 Access blocked" image instead of map tiles on every map screen. The cause is the applicationId, not osmdroid's configured user agent: TileSourceFactory.MAPNIK is built with TileSourcePolicy(2, 15), and flag 8 is FLAG_USER_AGENT_NORMALIZED. With that flag set, TileDownloader ignores Configuration.setUserAgentValue() and sends getNormalizedUserAgent() instead, which is literally packageName/versionCode. OSM blocks the Android-template com.example.* prefix, so every tile request identified the app as com.example.mobile_front_ma/1 and came back as the notice image.

Changed applicationId to rs.ac.uns.ftn.zgazenisendvic. namespace stays com.example.mobile_front_ma, so no Java package or R-class change is needed; Context.getPackageName() returns the applicationId at runtime.

Verified on an emulator: 24 of 24 cached tiles were byte-identical copies of the notice image before, and 0 after, with the map rendering normally.

Also moved the osmdroid setup out of MapFragment and RideHistoryDetailActivity into MobileFrontApp so it is configured once per process instead of being repeated by every screen that shows a map. GeoApiClient.USER_AGENT is now public and shared, which matters for tile sources that do not force a normalized agent.

Note the notice is served with HTTP 200, so osmdroid caches it like a valid tile. App data must be cleared after this change or the stale notices keep rendering.