### PR TITLE
Let the ride creator cancel their own ride

### DIFF
--- a/Back-end (ISS)/Server-Back-ISS/src/main/java/ZgazeniSendvic/Server_Back_ISS/service/RideServiceImpl.java
+++ b/Back-end (ISS)/Server-Back-ISS/src/main/java/ZgazeniSendvic/Server_Back_ISS/service/RideServiceImpl.java
@@ -321,7 +321,7 @@ public class RideServiceImpl implements IRideService {
 
         }
         //now check if passenger, if it is compare dates using the the 10 min func
-            boolean isPassenger = false;
+            boolean isPassenger = ride.getCreator() != null && Objects.equals(ride.getCreator().getId(), requester.getId());
             for(Account passenger : ride.getPassengers()){
                 if(Objects.equals(passenger.getId(), requester.getId())){
                     isPassenger = true;


### PR DESCRIPTION
canCancelRide only accepted the driver, an invited passenger or an admin. The creator is deliberately excluded from ride.passengers (resolveAccountsByEmails filters their email out, convertToRide copies only the invited list), so the user who actually ordered the ride always hit "Not passenger or Driver" - even though the ride shows up in their history. Treat the creator as a passenger, subject to the same 10-minute rule (spec 2.5).